### PR TITLE
Run setup.py (instead of just parsing it) to gather more data

### DIFF
--- a/py2pack/__init__.py
+++ b/py2pack/__init__.py
@@ -110,6 +110,9 @@ def _parse_setup_py(file, data):
     match = re.search("extras_require\s*=\s*(\{.*?\})", contents, flags=re.DOTALL)
     if match:
         data["extras_require"] = eval(match.group(1))
+    match = re.search("data_files\s*=\s*(\[.*?\])", contents, flags=re.DOTALL)
+    if match:
+        data["data_files"] = eval(match.group(1))
 
 
 def _run_setup_py(tarfile, setup_filename, data):
@@ -122,8 +125,16 @@ def _run_setup_py(tarfile, setup_filename, data):
     dist = distutils.core._setup_distribution
     shutil.rmtree(tempdir)
 
+    if dist.ext_modules:
+        data["is_extension"] = True
     if dist.scripts:
         data["scripts"] = dist.scripts
+    if dist.test_suite:
+        data["test_suite"] = dist.test_suite
+    if dist.install_requires:
+        data["install_requires"] = dist.install_requires
+    if dist.extras_require:
+        data["extras_require"] = dist.extras_require
     if dist.data_files:
         data["data_files"] = dist.data_files
 

--- a/py2pack/__init__.py
+++ b/py2pack/__init__.py
@@ -146,16 +146,18 @@ def _augment_data_from_tarball(args, filename, data):
     if tarfile.is_tarfile(filename):
         with tarfile.open(filename) as f:
             names = f.getnames()
-            _parse_setup_py(f.extractfile(setup_filename), data)
             if args.run:
                 _run_setup_py(f, setup_filename, data)
+            else:
+                _parse_setup_py(f.extractfile(setup_filename), data)
     elif zipfile.is_zipfile(filename):
         with zipfile.ZipFile(filename) as f:
             names = f.namelist()
-            with f.open(setup_filename) as s:
-                _parse_setup_py(s, data)
             if args.run:
                 _run_setup_py(f, setup_filename, data)
+            else:
+                with f.open(setup_filename) as s:
+                    _parse_setup_py(s, data)
     else:
         return
 

--- a/py2pack/__init__.py
+++ b/py2pack/__init__.py
@@ -179,6 +179,7 @@ def _canonicalize_setup_data(data):
 def _augment_data_from_tarball(args, filename, data):
     setup_filename = "{0}-{1}/setup.py".format(args.name, args.version)
     docs_re = re.compile("{0}-{1}\/((?:AUTHOR|ChangeLog|CHANGES|COPYING|LICENSE|NEWS|README).*)".format(args.name, args.version), re.IGNORECASE)
+    shell_metachars_re = re.compile("[|&;()<>\s]")
 
     if tarfile.is_tarfile(filename):
         with tarfile.open(filename) as f:
@@ -205,7 +206,10 @@ def _augment_data_from_tarball(args, filename, data):
         if match:
             if "doc_files" not in data:
                 data["doc_files"] = []
-            data["doc_files"].append(match.group(1))
+            if re.search(shell_metachars_re, match.group(1)):               # quote filename if it contains shell metacharacters
+                data["doc_files"].append("'" + match.group(1) + "'")
+            else:
+                data["doc_files"].append(match.group(1))
         if "test" in name.lower():                                          # Very broad check for testsuites
             data["testsuite"] = True
 

--- a/py2pack/templates/opensuse.spec
+++ b/py2pack/templates/opensuse.spec
@@ -82,12 +82,24 @@ nosetests
 %doc {{ doc_files|join(" ") }}
 {%- endif %}
 {%- for script in scripts %}
-%{_bindir}/{{ script }}
+%{_bindir}/{{ script|basename }}
 {%- endfor %}
 {%- if is_extension %}
 %{python_sitearch}/*
 {%- else %}
 %{python_sitelib}/*
 {%- endif %}
+{%- for dir, files in data_files %}
+{%- set dir =
+    ('/usr/'~dir if dir[0] != '/' else dir) |
+    replace('/usr/share/doc/'~name, '%doc %{_defaultdocdir}/%{name}', 1) |
+    replace('/usr/share/man/', '%doc %{_mandir}/', 1) |
+    replace('/usr/share/', '%{_datadir}/', 1) |
+    replace('/usr/', '%{_prefix}/', 1) %}
+%dir {{ dir }}
+{%- for file in files %}
+{{ dir }}/{{file|basename }}
+{%- endfor %}
+{%- endfor %}
 
 %changelog

--- a/py2pack/templates/opensuse.spec
+++ b/py2pack/templates/opensuse.spec
@@ -84,6 +84,9 @@ nosetests
 {%- for script in scripts %}
 %{_bindir}/{{ script|basename }}
 {%- endfor %}
+{%- for script in console_scripts %}
+%{_bindir}/{{ script }}
+{%- endfor %}
 {%- if is_extension %}
 %{python_sitearch}/*
 {%- else %}

--- a/py2pack/templates/opensuse.spec
+++ b/py2pack/templates/opensuse.spec
@@ -90,8 +90,7 @@ nosetests
 %{python_sitelib}/*
 {%- endif %}
 {%- for dir, files in data_files %}
-{%- set dir =
-    ('/usr/'~dir if dir[0] != '/' else dir) |
+{%- set dir = dir |
     replace('/usr/share/doc/'~name, '%doc %{_defaultdocdir}/%{name}', 1) |
     replace('/usr/share/man/', '%doc %{_mandir}/', 1) |
     replace('/usr/share/', '%{_datadir}/', 1) |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 argparse
 Jinja2
+setuptools


### PR DESCRIPTION
Hi Sascha,

I'd be interested to get feedback from you on this experimental feature and specifically on the following issues:

* tarfile.extractall() does not protect against overwriting files outside of tempdir (pathnames which are absolute or with "../" at the beginning; zipfile.extractall() attempts to prevent that). One solution would be to use setuptools.sandbox.DirectorySandbox. That's what setuptools.sandbox.run_setup() does. The downside is that obviously setuptools needs to be installed, so it adds another prerequisite to py2pack.

* setuptools.sandbox.run_setup() saves (and later restores) more state than I do, e.g. sys.modules and sys.argv. Not sure if that is actually necessary.

* Running setup.py is risky (execution of foreign/untrusted code). That is one of the reasons I've made this feature optional. However, _parse_setup_py() calls eval() on portions of setup.py so it can be argued that execution of foreign code already happens anyway.

* Execution of setup.py might fail. We could catch any exceptions and fall back to regular "parse" mode in that case.

Let me know what you think. Thanks.