### PR TITLE
Added BuildRequires: python-setuptools for opensuse.

### DIFF
--- a/py2pack/templates/opensuse.spec
+++ b/py2pack/templates/opensuse.spec
@@ -24,6 +24,7 @@ Url:            {{ home_page }}
 Group:          Development/Languages/Python
 Source:         {{ source_url|replace(version, '%{version}') }}
 BuildRequires:  python-devel {%- if requires_python %} = {{ requires_python }} {% endif %}
+BuildRequires:  python-setuptools
 {%- for req in requires %}
 BuildRequires:  python-{{ req|replace('(','')|replace(')','') }}
 Requires:       python-{{ req|replace('(','')|replace(')','') }}


### PR DESCRIPTION
maybe also needed for others?

@saschpe

Please review http://en.opensuse.org/openSUSE:Packaging_Python#The_fast_and_automated_way
it describes a workaround, that is no longer needed with this commit.