### PR TITLE
Fix license detection when license is None

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+# Docker Infrastructure (see http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/ )
+sudo: false
+
 language: python
 python:
   - 2.6
@@ -7,6 +10,7 @@ install:
   - pip install --use-mirrors -r test-requirements.txt
   - pip install --use-mirrors coveralls
 script:
-  coverage run --source=py2pack setup.py test
+  - flake8 py2pack
+  - coverage run --source=py2pack setup.py test
 after_success:
   coveralls

--- a/py2pack/__init__.py
+++ b/py2pack/__init__.py
@@ -35,17 +35,16 @@ import re
 import sys
 import tarfile
 import urllib
-#import warnings
+
 try:
     import xmlrpc.client as xmlrpclib
 except:
     import xmlrpclib
 import zipfile
 
-import py2pack.proxy
-
-#warnings.filterwarnings('ignore', 'Module argparse was already imported')   # Filter a UserWarning from Jinja2
 import jinja2
+
+import py2pack.proxy
 
 
 TEMPLATE_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'templates')  # absolute template path
@@ -126,11 +125,12 @@ def _augment_data_from_tarball(args, filename, data):
     for name in names:
         match = re.match(docs_re, name)
         if match:
-            if not "doc_files" in data:
+            if "doc_files" not in data:
                 data["doc_files"] = []
             data["doc_files"].append(match.group(1))
         if "test" in name.lower():                                          # Very broad check for testsuites
             data["testsuite"] = True
+
 
 def _normalize_license(data):
     """try to get SDPX license"""
@@ -139,6 +139,7 @@ def _normalize_license(data):
         data['license'] = SDPX_LICENSES[l]
     else:
         data['license'] = ""
+
 
 def generate(args):
     check_or_set_version(args)

--- a/py2pack/__init__.py
+++ b/py2pack/__init__.py
@@ -172,10 +172,6 @@ def generate(args):
         outfile.close()
 
 
-def create(args):
-    print('create package {0}...'.format(args.name))
-
-
 def check_or_set_version(args):
     if not args.version:                                                    # take first version found
         releases = pypi.package_releases(args.name)
@@ -200,10 +196,6 @@ def newest_download_url(args):
 
 def file_template_list():
     return [filename for filename in os.listdir(TEMPLATE_DIR) if not filename.startswith('.')]
-
-
-def package_template_list():
-    return ['obs']
 
 
 def main():
@@ -235,12 +227,6 @@ def main():
     parser_generate.add_argument('-t', '--template', choices=file_template_list(), default='opensuse.spec', help='file template')
     parser_generate.add_argument('-f', '--filename', help='spec filename (optional)')
     parser_generate.set_defaults(func=generate)
-
-    parser_do = subparsers.add_parser('create', help='generate complete package')
-    parser_do.add_argument('name', help='package name')
-    parser_do.add_argument('version', nargs='?', help='package version (optional)')
-    parser_do.add_argument('-t', '--template', choices=package_template_list(), default='obs', help='package template')
-    parser_do.set_defaults(func=create)
 
     parser_help = subparsers.add_parser('help', help='show this help')
     parser_help.set_defaults(func=lambda args: parser.print_help())

--- a/py2pack/__init__.py
+++ b/py2pack/__init__.py
@@ -132,6 +132,13 @@ def _augment_data_from_tarball(args, filename, data):
         if "test" in name.lower():                                          # Very broad check for testsuites
             data["testsuite"] = True
 
+def _normalize_license(data):
+    """try to get SDPX license"""
+    l = data.get('license', None)
+    if l and l in SDPX_LICENSES.keys():
+        data['license'] = SDPX_LICENSES[l]
+    else:
+        data['license'] = ""
 
 def generate(args):
     check_or_set_version(args)
@@ -154,8 +161,7 @@ def generate(args):
     if tarball_file:                                                        # get some more info from that
         _augment_data_from_tarball(args, tarball_file[0], data)
 
-    if data.get('license', "") in SDPX_LICENSES:                            # if we have a mapping, transform
-        data['license'] = SDPX_LICENSES[data['license']]                    # license into SPDX style
+    _normalize_license(data)
 
     template = env.get_template(args.template)
     result = template.render(data).encode('utf-8')                          # render template and encode properly

--- a/py2pack/setup.py
+++ b/py2pack/setup.py
@@ -55,17 +55,8 @@ class DocCommand(Command):
         try:
             subprocess.call(["xsltproc", "--output", "doc/py2pack.html", "/usr/share/xml/docbook/stylesheet/nwalsh/current/html/docbook.xsl", "doc/src/py2pack.xml.in"])
             subprocess.call(["xsltproc", "--output", "doc/py2pack.1", "/usr/share/xml/docbook/stylesheet/nwalsh/current/manpages/docbook.xsl", "doc/src/py2pack.xml.in"])
-            #subprocess.call(["xsltproc", "--output", "doc/py2pack.fo",
-            #                 "--stringparam", "paper.type", "A4",
-            #                 "--stringparam", "body.start.indent", "0pt",
-            #                 "--stringparam", "title.margin.left", "0pt",
-            #                 "--stringparam", "variablelist.as.blocks", "1",
-            #                 "/usr/share/xml/docbook/stylesheet/nwalsh/current/fo/docbook.xsl", "doc/py2pack.xml.in"])
-            #subprocess.call(["fop", "doc/py2pack.fo", "doc/py2pack.pdf"])
         except:
             pass
-        #if os.path.exists("doc/py2pack.fo"):
-        #    os.remove("doc/py2pack.fo")
 
 
 class SPDXUpdateCommand(Command):

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,3 +2,4 @@
 coverage
 flake8
 nose
+ddt

--- a/test/test_py2pack.py
+++ b/test/test_py2pack.py
@@ -17,10 +17,12 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
 
 import unittest
+from ddt import ddt, data, unpack
 
 import py2pack
 
 
+@ddt
 class Py2packTestCase(unittest.TestCase):
     def setUp(self):
         class Args:
@@ -45,3 +47,10 @@ class Py2packTestCase(unittest.TestCase):
         filename = "{0}-{1}.tar.gz".format(self.args.name, self.args.version)
         self.assertEqual(url["filename"], filename)
         self.assertEqual(url["packagetype"], "sdist")
+
+    @data((None, ""), ("Apache-2.0", "Apache-2.0"), ("", ""))
+    @unpack
+    def test_normalize_license(self, value, expected_result):
+        d = { 'license': value }
+        py2pack._normalize_license(d)
+        self.assertEqual(d['license'], expected_result)


### PR DESCRIPTION
A 'None' license resulted in a 'Unicode' license in the spec file while
generating a new .spec with 'py2pack generate'. Fix that and leave the
License empty in the spec.
Also add a test case for the license transformation.