### PR TITLE
Fix company name in spec template

### DIFF
--- a/py2pack/templates/opensuse.spec
+++ b/py2pack/templates/opensuse.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package python-{{ name }}
 #
-# Copyright (c) {{ year }} SUSE LINUX Products GmbH, Nuernberg, Germany.
+# Copyright (c) {{ year }} SUSE LINUX GmbH, Nuernberg, Germany.
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed


### PR DESCRIPTION
The new name of SUSE is "SUSE LINUX GmbH" without "Products".