### PR TITLE
Mention the "--run" as note in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,14 @@ generate a spec file (named 'python-zope.interface.spec'):
     $ py2pack generate zope.interface -t opensuse.spec -f python-zope.interface.spec
 
 The source tarball and the package recipe is all you need to generate the RPM_
-(or DEB_) file. This final step may depend on which distribution you use. Again,
+(or DEB_) file.
+
+.. note:: The "generate" operation is parsing the setup.py and tries to extract
+the needed information to generate a .spec file. That doesn't work in all cases.
+There is a "--run" option (:code:`py2pack generate --run`) which may give better
+results.
+
+This final step may depend on which distribution you use. Again,
 for openSUSE_ (and by using the `Open Build Service`_), the complete recipe is:
 
 .. code-block:: bash 


### PR DESCRIPTION
While describing the spec file generation with py2pack, mention
that there is the "py2pack generate --run" mode which may give
better results that the default setup.py parsing mode.