### PR TITLE
Requirement markers are only available in newer setuptools versions

### DIFF
--- a/py2pack/__init__.py
+++ b/py2pack/__init__.py
@@ -118,7 +118,7 @@ def _run_setup_py(tarfile, data):
 
 def _requirement_filter_by_marker(req):
     """check if the requirement is satisfied by the marker"""
-    if req.marker:
+    if hasattr(req, 'marker') and req.marker:
         # TODO (toabctl): currently we hardcode python 2.7 and linux2
         # see https://www.python.org/dev/peps/pep-0508/#environment-markers
         marker_env = {'python_version': '2.7', 'sys_platform': 'linux'}

--- a/py2pack/templates/opensuse.spec
+++ b/py2pack/templates/opensuse.spec
@@ -28,6 +28,12 @@ BuildRequires:  python-setuptools
 {%- for req in install_requires|sort %}
 BuildRequires:  python-{{ req|replace('(','')|replace(')','') }}
 {%- endfor %}
+{%- if tests_require %}
+# test requirements
+{%- for req in tests_require|sort %}
+BuildRequires:  python-{{ req|replace('(','')|replace(')','') }}
+{%- endfor %}
+{%- endif %}
 {%- if source_url.endswith('.zip') %}
 BuildRequires:  unzip
 {%- endif %}

--- a/py2pack/templates/opensuse.spec
+++ b/py2pack/templates/opensuse.spec
@@ -25,13 +25,15 @@ Group:          Development/Languages/Python
 Source:         {{ source_url|replace(version, '%{version}') }}
 BuildRequires:  python-devel {%- if requires_python %} = {{ requires_python }} {% endif %}
 BuildRequires:  python-setuptools
-{%- for req in install_requires %}
+{%- for req in install_requires|sort %}
 BuildRequires:  python-{{ req|replace('(','')|replace(')','') }}
-Requires:       python-{{ req|replace('(','')|replace(')','') }}
 {%- endfor %}
 {%- if source_url.endswith('.zip') %}
 BuildRequires:  unzip
 {%- endif %}
+{%- for req in install_requires|sort %}
+Requires:       python-{{ req|replace('(','')|replace(')','') }}
+{%- endfor %}
 {%- if extras_require %}
 {%- for reqlist in extras_require.values() %}
 {%- for req in reqlist %}


### PR DESCRIPTION
This fixes:

AttributeError: Requirement instance has no attribute 'marker'#