### PR TITLE
Fix --run deprecation

### DIFF
--- a/py2pack/__init__.py
+++ b/py2pack/__init__.py
@@ -157,9 +157,22 @@ def _augment_data_from_tarball(args, filename, data):
             data["testsuite"] = True
 
 
+def _license_from_classifiers(data):
+    """try to get a license from the classifiers"""
+    classifiers = data.get('classifiers', [])
+    found_license = None
+    for c in classifiers:
+        if c.startswith("License :: OSI Approved :: "):
+            found_license = c.replace("License :: OSI Approved :: ", "")
+    return found_license
+
+
 def _normalize_license(data):
     """try to get SDPX license"""
     l = data.get('license', None)
+    if not l:
+        # try to get license from classifiers
+        l = _license_from_classifiers(data)
     if l and l in SDPX_LICENSES.keys():
         data['license'] = SDPX_LICENSES[l]
     else:

--- a/py2pack/__init__.py
+++ b/py2pack/__init__.py
@@ -153,7 +153,8 @@ def _augment_data_from_tarball(args, filename, data):
                 data["doc_files"].append("'" + match.group(1) + "'")
             else:
                 data["doc_files"].append(match.group(1))
-        if "test" in name.lower():                                          # Very broad check for testsuites
+        # Very broad check for testsuites
+        if "test" in name.lower():
             data["testsuite"] = True
 
 

--- a/py2pack/__init__.py
+++ b/py2pack/__init__.py
@@ -21,7 +21,7 @@ from __future__ import absolute_import
 __doc__ = 'Generate distribution packages from PyPI'
 __docformat__ = 'restructuredtext en'
 __author__ = 'Sascha Peilicke <sascha@peilicke.de>'
-__version__ = '0.6.2'
+__version__ = '0.6.3'
 
 import argparse
 import datetime

--- a/py2pack/__init__.py
+++ b/py2pack/__init__.py
@@ -47,13 +47,6 @@ import py2pack.utils
 TEMPLATE_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'templates')
 pypi = xmlrpc_client.ServerProxy('https://pypi.python.org/pypi')
 
-# setup jinja2 environment with custom filters
-env = jinja2.Environment(loader=jinja2.FileSystemLoader(TEMPLATE_DIR))
-env.filters['parenthesize_version'] = \
-    lambda s: re.sub('([=<>]+)(.+)', r' (\1 \2)', s)
-env.filters['basename'] = \
-    lambda s: s[s.rfind('/') + 1:]
-
 SPDX_LICENSES_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'spdx_license_map.p')
 SDPX_LICENSES = pickle.load(open(SPDX_LICENSES_FILE, 'rb'))
 
@@ -180,6 +173,16 @@ def _normalize_license(data):
         data['license'] = ""
 
 
+def _prepare_template_env(template_dir):
+    # setup jinja2 environment with custom filters
+    env = jinja2.Environment(loader=jinja2.FileSystemLoader(template_dir))
+    env.filters['parenthesize_version'] = \
+        lambda s: re.sub('([=<>]+)(.+)', r' (\1 \2)', s)
+    env.filters['basename'] = \
+        lambda s: s[s.rfind('/') + 1:]
+    return env
+
+
 def generate(args):
     # TODO (toabctl): remove this is a later release
     if args.run:
@@ -208,6 +211,7 @@ def generate(args):
 
     _normalize_license(data)
 
+    env = _prepare_template_env(TEMPLATE_DIR)
     template = env.get_template(args.template)
     result = template.render(data).encode('utf-8')                          # render template and encode properly
     outfile = open(args.filename, 'wb')                                     # write result to spec file

--- a/py2pack/__init__.py
+++ b/py2pack/__init__.py
@@ -167,6 +167,11 @@ def _normalize_license(data):
 
 
 def generate(args):
+    # TODO (toabctl): remove this is a later release
+    if args.run:
+        warnings.warn("the '--run' switch is deprecated and a noop",
+                      DeprecationWarning)
+
     check_or_set_version(args)
     if not args.template:
         args.template = file_template_list()[0]
@@ -262,11 +267,6 @@ def main():
     parser_help.set_defaults(func=lambda args: parser.print_help())
 
     args = parser.parse_args()
-
-    # TODO (toabctl): remove this is a later release
-    if args.run:
-        warnings.warn("the '--run' switch is deprecated and a noop",
-                      DeprecationWarning)
 
     # set HTTP proxy if one is provided
     if args.proxy:

--- a/py2pack/get_metadata.py
+++ b/py2pack/get_metadata.py
@@ -41,19 +41,19 @@ class get_metadata(Command):
         data = {}
         if self.distribution.has_ext_modules():
             data["is_extension"] = True
-        if getattr(self.distribution, "scripts"):
+        if getattr(self.distribution, "scripts", None):
             data["scripts"] = self.distribution.scripts
-        if getattr(self.distribution, "test_suite"):
+        if getattr(self.distribution, "test_suite", None):
             data["test_suite"] = self.distribution.test_suite
-        if getattr(self.distribution, "install_requires"):
+        if getattr(self.distribution, "install_requires", None):
             data["install_requires"] = self.distribution.install_requires
-        if getattr(self.distribution, "extras_require"):
+        if getattr(self.distribution, "extras_require", None):
             data["extras_require"] = self.distribution.extras_require
-        if getattr(self.distribution, "tests_require"):
+        if getattr(self.distribution, "tests_require", None):
             data["tests_require"] = self.distribution.tests_require
-        if getattr(self.distribution, "data_files"):
+        if getattr(self.distribution, "data_files", None):
             data["data_files"] = self.distribution.data_files
-        if getattr(self.distribution, "entry_points"):
+        if getattr(self.distribution, "entry_points", None):
             data["entry_points"] = self.distribution.entry_points
 
         if self.output:

--- a/py2pack/requires.py
+++ b/py2pack/requires.py
@@ -27,6 +27,16 @@ import subprocess
 import tempfile
 
 
+def _set_source_encoding_utf8(setup_py_file):
+    """set a encoding header as suggested in PEP-0263. This
+    is not entirely correct because we don't know the encoding of the
+    given file but it's at least a chance to get metadata from the setup.py"""
+    with open(setup_py_file, 'r+') as f:
+        content = f.read()
+        f.seek(0, 0)
+        f.write("# -*- coding: utf-8 -*-\n" + content)
+
+
 def _requires_from_setup_py_run(tmp_dir):
     """run the get_metadata command via the setup.py in the given tmp_dir.
     the output of get_metadata is json and is stored in a tempfile
@@ -44,7 +54,13 @@ def _requires_from_setup_py_run(tmp_dir):
         # generate a temporary json file which contains the metadata
         cmd = "python setup.py -q --command-packages py2pack " \
               "get_metadata -o %s " % tempfile_json.name
-        subprocess.check_output(cmd, shell=True)
+        try:
+            subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
+        except subprocess.CalledProcessError:
+            # try again with a encoding in setup.py
+            _set_source_encoding_utf8("setup.py")
+            subprocess.check_output(cmd, shell=True)
+
         with open(tempfile_json.name, "r") as f:
             data = json.loads(f.read())
     finally:

--- a/py2pack/templates/opensuse.spec
+++ b/py2pack/templates/opensuse.spec
@@ -71,13 +71,8 @@ BuildArch:      noarch
 python setup.py install --prefix=%{_prefix} --root=%{buildroot}
 
 {%- if testsuite or test_suite %}
-
 %check
-  {%- if test_suite %}
 python setup.py test
-  {%- else %}
-nosetests
-  {%- endif %}
 {%- endif %}
 
 %files

--- a/test/test_py2pack.py
+++ b/test/test_py2pack.py
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import unittest
 from ddt import ddt, data, unpack
 
@@ -71,6 +72,14 @@ class Py2packTestCase(unittest.TestCase):
     def test_license_from_classifiers(self, value, expected):
         d = {'classifiers': value}
         self.assertEqual(py2pack._license_from_classifiers(d), expected)
+
+    def test__prepare_template_env(self):
+        template_dir = os.path.join(os.path.dirname(
+            os.path.abspath(__file__)), '..', 'py2pack', 'templates')
+        env = py2pack._prepare_template_env(template_dir)
+        self.assertTrue('opensuse.spec' in env.list_templates())
+        self.assertTrue('parenthesize_version' in env.filters)
+        self.assertTrue('basename' in env.filters)
 
     @data(
         (

--- a/test/test_py2pack.py
+++ b/test/test_py2pack.py
@@ -48,13 +48,29 @@ class Py2packTestCase(unittest.TestCase):
         self.assertEqual(url["filename"], filename)
         self.assertEqual(url["packagetype"], "sdist")
 
-    @data((None, ""), ("Apache-2.0", "Apache-2.0"), ("", ""),
-          ("Apache 2.0", "Apache-2.0"))
+    @data(
+        (None, [], ""),
+        ("Apache-2.0", [], "Apache-2.0"),
+        ("", [], ""),
+        ("Apache 2.0", [], "Apache-2.0"),
+        ("", ["License :: OSI Approved :: Apache Software License"], "Apache-2.0"),
+    )
     @unpack
-    def test_normalize_license(self, value, expected_result):
-        d = {'license': value}
+    def test_normalize_license(self, licenses, classifiers, expected_result):
+        d = {'license': licenses, 'classifiers': classifiers}
         py2pack._normalize_license(d)
         self.assertEqual(d['license'], expected_result)
+
+    @data(
+        ([""], None),
+        (["foobar"], None),
+        (["foobar", "License :: OSI Approved :: Apache Software License"],
+         "Apache Software License"),
+    )
+    @unpack
+    def test_license_from_classifiers(self, value, expected):
+        d = {'classifiers': value}
+        self.assertEqual(py2pack._license_from_classifiers(d), expected)
 
     @data(
         (

--- a/test/test_requires.py
+++ b/test/test_requires.py
@@ -40,6 +40,12 @@ class Py2packRequiresTestCase(unittest.TestCase):
         with open(self.setup_py, 'w+') as f:
             f.write(content)
 
+    def test__set_source_encoding_utf8(self):
+        self._write_setup_py("")
+        py2pack.requires._set_source_encoding_utf8(self.setup_py)
+        with open(self.setup_py, 'r') as f:
+            self.assertEqual(f.read(), "# -*- coding: utf-8 -*-\n")
+
     def test__requires_from_setup_py_run(self):
         self._write_setup_py("""
 import setuptools
@@ -68,6 +74,22 @@ setuptools.setup(
 
     def test__requires_from_setup_py_run_distutils(self):
         self._write_setup_py("""# -*- coding: utf8 -*-
+from distutils.core import setup
+setup(
+    version="0.3.1",
+    author="的å",
+    package_dir={"": "test"},
+    py_modules=["test"],
+    scripts=[
+        "bin/test",
+        ]
+)
+""")
+        data = py2pack.requires._requires_from_setup_py_run(self.tmpdir)
+        self.assertEqual(data, {'scripts': ['bin/test']})
+
+    def test__requires_from_setup_py_run_unknown_encoding(self):
+        self._write_setup_py("""
 from distutils.core import setup
 setup(
     version="0.3.1",

--- a/test/test_requires.py
+++ b/test/test_requires.py
@@ -66,6 +66,22 @@ setuptools.setup(
         self.assertEqual(data, {'install_requires': ['foo', 'bar'],
                                 'tests_require': ['test']})
 
+    def test__requires_from_setup_py_run_distutils(self):
+        self._write_setup_py("""# -*- coding: utf8 -*-
+from distutils.core import setup
+setup(
+    version="0.3.1",
+    author="的å",
+    package_dir={"": "test"},
+    py_modules=["test"],
+    scripts=[
+        "bin/test",
+        ]
+)
+""")
+        data = py2pack.requires._requires_from_setup_py_run(self.tmpdir)
+        self.assertEqual(data, {'scripts': ['bin/test']})
+
     @data(
         ("pywin32>=1.0;sys_platform=='win32'  # PSF", False),
         ("foobar", True),


### PR DESCRIPTION
Move the code to the correct place - inside of the "generate()" function.
This fixes:

AttributeError: 'Namespace' object has no attribute 'run'