### PR TITLE
Add "metadata" subcommand

### DIFF
--- a/py2pack/__init__.py
+++ b/py2pack/__init__.py
@@ -26,6 +26,7 @@ __version__ = '0.6.3'
 import argparse
 import datetime
 import glob
+import json
 import os
 import pickle
 import pkg_resources
@@ -69,6 +70,13 @@ def show(args):
     print('showing package {0}...'.format(args.name))
     data = pypi.release_data(args.name, args.version)
     pprint.pprint(data)
+
+
+def metadata(args):
+    """extra the metadata from the given tarball"""
+    data = {}
+    _run_setup_py(args.filename, data)
+    print(json.dumps(data, indent=4, sort_keys=True))
 
 
 def fetch(args):
@@ -265,6 +273,11 @@ def main():
     parser_show.add_argument('name', help='package name')
     parser_show.add_argument('version', nargs='?', help='package version (optional)')
     parser_show.set_defaults(func=show)
+
+    parser_metadata = subparsers.add_parser('metadata',
+                                            help='show metadata for a given tarball')
+    parser_metadata.add_argument('filename', help='filename')
+    parser_metadata.set_defaults(func=metadata)
 
     parser_fetch = subparsers.add_parser('fetch', help='download package source tarball from PyPI')
     parser_fetch.add_argument('name', help='package name')

--- a/py2pack/__init__.py
+++ b/py2pack/__init__.py
@@ -21,7 +21,7 @@ from __future__ import absolute_import
 __doc__ = 'Generate distribution packages from PyPI'
 __docformat__ = 'restructuredtext en'
 __author__ = 'Sascha Peilicke <sascha@peilicke.de>'
-__version__ = '0.6.3'
+__version__ = '0.6.4'
 
 import argparse
 import datetime


### PR DESCRIPTION
With the new subcommand called via "py2pack metadata FILENAME"
py2pack will extract the metadata from a given tarball (which must
contain a valid setup.py file).
The metadata currently contains only the requirements.